### PR TITLE
Use long format name instead of alias #3

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -30,7 +30,7 @@ func newConn(cfg *Config) *conn {
 		logger = log.New(os.Stderr, "clickhouse: ", log.LstdFlags)
 	}
 	c := &conn{
-		url:      cfg.url(map[string]string{"default_format": "TSVWithNamesAndTypes"}, false),
+		url:      cfg.url(map[string]string{"default_format": "TabSeparatedWithNamesAndTypes"}, false),
 		location: cfg.Location,
 		transport: &http.Transport{
 			DialContext: (&net.Dialer{


### PR DESCRIPTION
TSVWithNamesAndTypes alias has been added only in version: v1.1.54267-testing
This patch fixes compatibility with earlier versions.