### PR TITLE
add type UInt64 to avoid database/sql limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ http://user:password@host:8123/clicks?read_timeout=10&write_timeout=20
 * Enum
 * [Array(T) (one-dimensional)](https://clickhouse.yandex/reference_en.html#Array(T))
 
+Note:
+database/sql does not allow to use big uint64 values.
+It is recommended use type `UInt64` which is provided by driver for such kind of values.
 
 ## Install
 ```

--- a/conn_test.go
+++ b/conn_test.go
@@ -85,6 +85,11 @@ func (s *connSuite) TestExec() {
 			[]interface{}{int64(3), Array([]int16{1, 2})},
 		},
 		{
+			"INSERT INTO data (u64) VALUES (?)",
+			"",
+			[]interface{}{UInt64(uint64(1) << 63)},
+		},
+		{
 			"INSERT INTO data (d, t) VALUES (?, ?)",
 			"",
 			[]interface{}{

--- a/types.go
+++ b/types.go
@@ -2,6 +2,7 @@ package clickhouse
 
 import (
 	"database/sql/driver"
+	"strconv"
 	"time"
 )
 
@@ -13,6 +14,11 @@ func Array(v interface{}) driver.Valuer {
 // Date returns date for t
 func Date(t time.Time) driver.Valuer {
 	return date(t)
+}
+
+// UInt64 returns date for t
+func UInt64(u uint64) driver.Valuer {
+	return bigUint64(u)
 }
 
 type array struct {
@@ -29,4 +35,11 @@ type date time.Time
 // Value implements driver.Valuer
 func (d date) Value() (driver.Value, error) {
 	return []byte(formatDate(time.Time(d))), nil
+}
+
+type bigUint64 uint64
+
+// Value implements driver.Valuer
+func (u bigUint64) Value() (driver.Value, error) {
+	return []byte(strconv.FormatUint(uint64(u), 10)), nil
 }

--- a/types_test.go
+++ b/types_test.go
@@ -37,3 +37,11 @@ func TestDate(t *testing.T) {
 		assert.Equal(t, []byte("'2016-04-04'"), dv)
 	}
 }
+
+func TestUInt64(t *testing.T) {
+	u := uint64(1) << 63
+	dv, err := UInt64(u).Value()
+	if assert.NoError(t, err) {
+		assert.Equal(t, []byte("9223372036854775808"), dv)
+	}
+}


### PR DESCRIPTION
the golang database/sql does to allow to use big uint64 values.
this PR provides a new type UInt64, which allows to wrap such kind of values to use in the driver.
fixes issue #11