### PR TITLE
use post-method in both readonly and non-readonly queries

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -227,7 +227,7 @@ func (c *conn) buildRequest(query string, params []driver.Value, readonly bool) 
 		q := u.Query()
 		q.Set("query", query)
 		u.RawQuery = q.Encode()
-		req, err = http.NewRequest(http.MethodGet, u.String(), nil)
+		req, err = http.NewRequest(http.MethodPost, u.String(), nil)
 	} else {
 		req, err = http.NewRequest(http.MethodPost, c.url.String(), strings.NewReader(query))
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -158,7 +158,7 @@ func (s *connSuite) TestBuildRequestReadonlyWithAuth() {
 		s.True(ok)
 		s.Equal("user", user)
 		s.Equal("password", password)
-		s.Equal(http.MethodGet, req.Method)
+		s.Equal(http.MethodPost, req.Method)
 		s.Equal(cn.url.String()+"&query=SELECT+1", req.URL.String())
 		s.Nil(req.URL.User)
 	}


### PR DESCRIPTION
Все запросы в кликхаус теперь делаются с методом POST, независимо от того, проставлен ли им статус read-only