### PR TITLE
Revert "Merge pull request #22 from azaikin/query-url"

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -213,25 +213,21 @@ func (c *conn) doRequest(ctx context.Context, req *http.Request) ([]byte, error)
 
 func (c *conn) buildRequest(query string, params []driver.Value, readonly bool) (*http.Request, error) {
 	var (
-		req *http.Request
-		err error
+		method string
+		err    error
 	)
 	if params != nil {
 		if query, err = interpolateParams(query, params); err != nil {
 			return nil, err
 		}
 	}
-	c.log("query: ", query)
 	if readonly {
-		u := *c.url
-		q := u.Query()
-		q.Set("query", query)
-		u.RawQuery = q.Encode()
-		req, err = http.NewRequest(http.MethodGet, u.String(), nil)
+		method = http.MethodGet
 	} else {
-		req, err = http.NewRequest(http.MethodPost, c.url.String(), strings.NewReader(query))
+		method = http.MethodPost
 	}
-
+	c.log("query: ", query)
+	req, err := http.NewRequest(method, c.url.String(), strings.NewReader(query))
 	// http.Transport ignores url.User argument, handle it here
 	if err == nil && c.user != nil {
 		p, _ := c.user.Password()

--- a/conn_test.go
+++ b/conn_test.go
@@ -159,7 +159,7 @@ func (s *connSuite) TestBuildRequestReadonlyWithAuth() {
 		s.Equal("user", user)
 		s.Equal("password", password)
 		s.Equal(http.MethodGet, req.Method)
-		s.Equal(cn.url.String()+"&query=SELECT+1", req.URL.String())
+		s.Equal(cn.url.String(), req.URL.String())
 		s.Nil(req.URL.User)
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -16,7 +16,7 @@ var (
 	ErrNoRowsAffected   = errors.New("no RowsAffected available")
 )
 
-var errorRe = regexp.MustCompile(`(?s)Code: (\d+),.+DB::Exception: (.+),.*`)
+var errorRe = regexp.MustCompile(`Code: (\d+),.+DB::Exception: (.+),.*`)
 
 // Error contains parsed information about server error
 type Error struct {

--- a/errors.go
+++ b/errors.go
@@ -16,7 +16,7 @@ var (
 	ErrNoRowsAffected   = errors.New("no RowsAffected available")
 )
 
-var errorRe = regexp.MustCompile(`Code: (\d+),.+DB::Exception: (.+),.*`)
+var errorRe = regexp.MustCompile(`(?s)Code: (\d+),.+DB::Exception: (.+),.*`)
 
 // Error contains parsed information about server error
 type Error struct {


### PR DESCRIPTION
This reverts commit 1d0076b2e74b0057628a7bb22a0113fb0cabfc05, reversing
changes made to 7cb83a2242fff54a3629866bdab9479eef95cd76.

В read-only запросах текст запроса передается через тело запроса, а не через урл.