### PR TITLE
Streaming query

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -168,7 +169,8 @@ func (c *conn) query(ctx context.Context, query string, args []driver.Value) (dr
 	if err != nil {
 		return nil, err
 	}
-	return newTextRows(body, c.location, c.useDBLocation)
+
+	return newTextRows(c, body, c.location, c.useDBLocation)
 }
 
 func (c *conn) exec(ctx context.Context, query string, args []driver.Value) (driver.Result, error) {
@@ -183,32 +185,33 @@ func (c *conn) exec(ctx context.Context, query string, args []driver.Value) (dri
 	return emptyResult, err
 }
 
-func (c *conn) doRequest(ctx context.Context, req *http.Request) ([]byte, error) {
+func (c *conn) doRequest(ctx context.Context, req *http.Request) (io.ReadCloser, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	transport := c.transport
 	c.cancel = cancel
 
-	defer func() {
-		c.cancel = nil
-	}()
-
 	if transport == nil {
+		c.cancel = nil
 		return nil, driver.ErrBadConn
 	}
 
 	req = req.WithContext(ctx)
 	resp, err := transport.RoundTrip(req)
 	if err != nil {
+		c.cancel = nil
 		return nil, err
 	}
 	if resp.StatusCode != 200 {
 		msg, err := readResponse(resp)
 		if err != nil {
+			c.cancel = nil
 			return nil, err
 		}
+		c.cancel = nil
 		return nil, newError(string(msg))
 	}
-	return readResponse(resp)
+
+	return resp.Body, nil
 }
 
 func (c *conn) buildRequest(query string, params []driver.Value, readonly bool) (*http.Request, error) {

--- a/rows_test.go
+++ b/rows_test.go
@@ -1,8 +1,10 @@
 package clickhouse
 
 import (
+	"bytes"
 	"database/sql/driver"
 	"io"
+	"io/ioutil"
 	"reflect"
 	"testing"
 	"time"
@@ -10,8 +12,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type bufReadCloser struct {
+	*bytes.Reader
+}
+
+func (r *bufReadCloser) Close() error {
+	return nil
+}
+
 func TestTextRows(t *testing.T) {
-	rows, err := newTextRows([]byte("Number\tText\nInt32\tString\n1\t'hello'\n2\t'world'\n"), time.Local, false)
+	buf := bytes.NewReader([]byte("Number\tText\nInt32\tString\n1\t'hello'\n2\t'world'\n"))
+	rows, err := newTextRows(&conn{}, &bufReadCloser{buf}, time.Local, false)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -32,8 +43,13 @@ func TestTextRows(t *testing.T) {
 		return
 	}
 	assert.Equal(t, []driver.Value{int32(2), "world"}, dest)
-	assert.Equal(t, 0, len(rows.data))
+	data, err := ioutil.ReadAll(rows.respBody)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, 0, len(data))
 	assert.Equal(t, io.EOF, rows.Next(dest))
 	assert.NoError(t, rows.Close())
-	assert.Nil(t, rows.data)
+	assert.Empty(t, data)
 }


### PR DESCRIPTION
An alternative approach to #37. Being not aware of that pull request I did something similar myself.

Here is a list of changes I introduce:
* instead of passing `[]byte` as a result of `*conn.doRequest` slice I simply pass the `resp.Body` which is an `io.ReadCloser`
* I also use csv.Reader which eliminates the need for the unfinished data handling
* I let the underlying transport handle buffering

This approach makes issues like #39 easier for fix, as only decorating the io.Reader with a ungzipper reader would be necessary.

Resolves #34 