### PR TITLE
Simplify compressed response handling

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1,7 +1,6 @@
 package clickhouse
 
 import (
-	"compress/gzip"
 	"context"
 	"database/sql"
 	"database/sql/driver"
@@ -213,15 +212,7 @@ func (c *conn) doRequest(ctx context.Context, req *http.Request) (io.ReadCloser,
 		return nil, err
 	}
 
-	respBody := resp.Body
-	if resp.Header.Get("Content-Encoding") == "gzip" {
-		respBody, err = gzip.NewReader(respBody)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return respBody, nil
+	return resp.Body, nil
 }
 
 func (c *conn) buildRequest(query string, params []driver.Value, readonly bool) (*http.Request, error) {
@@ -245,9 +236,6 @@ func (c *conn) buildRequest(query string, params []driver.Value, readonly bool) 
 	if err == nil && c.user != nil {
 		p, _ := c.user.Password()
 		req.SetBasicAuth(c.user.Username(), p)
-	}
-	if c.useGzipCompression {
-		req.Header.Set("Accept-Encoding", "gzip")
 	}
 
 	return req, err


### PR DESCRIPTION
This commit simplifies gzip compressed response handling.
Godoc clearly says that by default http.Transport will
add 'Accept-Encoding: gzip' to a Request and transparently
decode the response if a 'Content-Encoding: gzip' header
is present.
See https://golang.org/src/net/http/transport.go#L181

Therefore it is only necessary to add "enable_http_compression=1"
HTTP query parameter to Clickhouse server requests.