### PR TITLE
Fix for multiline insert queries

### DIFF
--- a/stmt.go
+++ b/stmt.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	splitInsertRe = regexp.MustCompile(`(.+\s+VALUES)\s*(\(.+\))`)
+	splitInsertRe = regexp.MustCompile(`(?s)(.+\s+VALUES)\s*(\(.+\))`)
 )
 
 type stmt struct {

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -221,18 +221,6 @@ func (s *stmtSuite) TestFixDoubleInterpolateInStmt() {
 	s.NoError(rows.Close())
 }
 
-func (s *stmtSuite) TestFixMultiLineInsert() {
-	q := `
-INSERT INTO tbl (
-a
-) VALUES (
-?
-)
-`
-	st := newStmt(q)
-	s.True(st.batchMode)
-}
-
 func TestStmt(t *testing.T) {
 	suite.Run(t, new(stmtSuite))
 }

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -194,6 +194,18 @@ func (s *stmtSuite) TestFixDoubleInterpolateInStmt() {
 	s.NoError(rows.Close())
 }
 
+func (s *stmtSuite) TestFixMultiLineInsert() {
+	q := `
+INSERT INTO tbl (
+a
+) VALUES (
+?
+)
+`
+	st := newStmt(q)
+	s.True(st.batchMode)
+}
+
 func TestStmt(t *testing.T) {
 	suite.Run(t, new(stmtSuite))
 }


### PR DESCRIPTION
When insert query contains multiple lines batchmode is not working.

To fix that I have added regexp flag to match  "." to "\n"