### PR TITLE
Close unused response bodies to avoid leaks.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -183,7 +183,10 @@ func (c *conn) exec(ctx context.Context, query string, args []driver.Value) (dri
 	if err != nil {
 		return nil, err
 	}
-	_, err = c.doRequest(ctx, req)
+	body, err := c.doRequest(ctx, req)
+	if body != nil {
+		body.Close()
+	}
 	return emptyResult, err
 }
 


### PR DESCRIPTION
Issuing too many Exec()s leads to file descriptor exhaustion on Linux. This PR closes the response body in exec() before returning. Fixes #50 as @theoptz suggested.