### PR TITLE
Use custom TLS configuration #41

### DIFF
--- a/config.go
+++ b/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	UseDBLocation   bool
 	GzipCompression bool
 	Params          map[string]string
+	TLSConfig       string
 }
 
 // NewConfig creates a new config with default values
@@ -154,6 +155,8 @@ func parseDSNParams(cfg *Config, params map[string][]string) (err error) {
 		case "enable_http_compression":
 			cfg.GzipCompression, err = strconv.ParseBool(v[0])
 			cfg.Params[k] = v[0]
+		case "tls_config":
+			cfg.TLSConfig = v[0]
 		default:
 			cfg.Params[k] = v[0]
 		}

--- a/conn.go
+++ b/conn.go
@@ -61,6 +61,7 @@ func newConn(cfg *Config) *conn {
 			MaxIdleConns:          1,
 			IdleConnTimeout:       cfg.IdleTimeout,
 			ResponseHeaderTimeout: cfg.ReadTimeout,
+			TLSClientConfig:       getTLSConfigClone(cfg.TLSConfig),
 		},
 		logger: logger,
 	}

--- a/tls_config.go
+++ b/tls_config.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 )
 
-// Based on the original implementation in go-sql-driver/mysql:
+// Based on the original implementation in the project go-sql-driver/mysql:
 // https://github.com/go-sql-driver/mysql/blob/master/utils.go
 
 var (

--- a/tls_config.go
+++ b/tls_config.go
@@ -1,0 +1,44 @@
+package clickhouse
+
+import (
+	"crypto/tls"
+	"sync"
+)
+
+// Based on the original implementation in go-sql-driver/mysql:
+// https://github.com/go-sql-driver/mysql/blob/master/utils.go
+
+var (
+	tlsConfigLock     sync.RWMutex
+	tlsConfigRegistry map[string]*tls.Config
+)
+
+// RegisterTLSConfig registers a custom tls.Config to be used with sql.Open.
+func RegisterTLSConfig(key string, config *tls.Config) error {
+	tlsConfigLock.Lock()
+	if tlsConfigRegistry == nil {
+		tlsConfigRegistry = make(map[string]*tls.Config)
+	}
+
+	tlsConfigRegistry[key] = config
+	tlsConfigLock.Unlock()
+	return nil
+}
+
+// DeregisterTLSConfig removes the tls.Config associated with key.
+func DeregisterTLSConfig(key string) {
+	tlsConfigLock.Lock()
+	if tlsConfigRegistry != nil {
+		delete(tlsConfigRegistry, key)
+	}
+	tlsConfigLock.Unlock()
+}
+
+func getTLSConfigClone(key string) (config *tls.Config) {
+	tlsConfigLock.RLock()
+	if v, ok := tlsConfigRegistry[key]; ok {
+		config = v.Clone()
+	}
+	tlsConfigLock.RUnlock()
+	return
+}


### PR DESCRIPTION
This PR adds support for custom TLS configuration, defined by the end user.

Based on the original implementation for: https://github.com/go-sql-driver/mysql

Fixes #41

/cc @bgaifullin 