### PR TITLE
Support priority argument

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	GzipCompression bool
 	Params          map[string]string
 	TLSConfig       string
+	Priority        int
 }
 
 // NewConfig creates a new config with default values
@@ -60,6 +61,9 @@ func (cfg *Config) FormatDSN() string {
 	}
 	if cfg.GzipCompression {
 		query.Set("enable_http_compression", "1")
+	}
+	if cfg.Priority != 0 {
+		query.Set("priority", strconv.Itoa(cfg.Priority))
 	}
 	if cfg.Debug {
 		query.Set("debug", "1")
@@ -157,6 +161,9 @@ func parseDSNParams(cfg *Config, params map[string][]string) (err error) {
 			cfg.Params[k] = v[0]
 		case "tls_config":
 			cfg.TLSConfig = v[0]
+		case "priority":
+			cfg.Priority, err = strconv.Atoi(v[0])
+			cfg.Params[k] = v[0]
 		default:
 			cfg.Params[k] = v[0]
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestParseDSN(t *testing.T) {
 	dsn := "http://username:password@localhost:8123/test?timeout=1s&idle_timeout=2s&read_timeout=3s" +
-		"&write_timeout=4s&location=Local&max_execution_time=10&debug=1"
+		"&write_timeout=4s&location=Local&max_execution_time=10&debug=1&priority=10"
 	cfg, err := ParseDSN(dsn)
 	if assert.NoError(t, err) {
 		assert.Equal(t, "username", cfg.User)
@@ -23,7 +23,8 @@ func TestParseDSN(t *testing.T) {
 		assert.Equal(t, 4*time.Second, cfg.WriteTimeout)
 		assert.Equal(t, time.Local, cfg.Location)
 		assert.True(t, cfg.Debug)
-		assert.Equal(t, map[string]string{"max_execution_time": "10"}, cfg.Params)
+		assert.Equal(t, map[string]string{"max_execution_time": "10", "priority": "10"}, cfg.Params)
+		assert.Equal(t, 10, cfg.Priority)
 	}
 }
 
@@ -60,7 +61,7 @@ func TestParseWrongDSN(t *testing.T) {
 
 func TestFormatDSN(t *testing.T) {
 	dsn := "http://username:password@localhost:8123/test?timeout=1s&idle_timeout=2s&read_timeout=3s" +
-		"&write_timeout=4s&location=Europe%2FMoscow&max_execution_time=10&debug=1"
+		"&write_timeout=4s&location=Europe%2FMoscow&max_execution_time=10&debug=1&priority=10"
 	cfg, err := ParseDSN(dsn)
 	if assert.NoError(t, err) {
 		dsn2 := cfg.FormatDSN()
@@ -73,20 +74,24 @@ func TestFormatDSN(t *testing.T) {
 		assert.Contains(t, dsn2, "location=Europe%2FMoscow")
 		assert.Contains(t, dsn2, "max_execution_time=10")
 		assert.Contains(t, dsn2, "debug=1")
+		assert.Contains(t, dsn2, "priority=10")
 	}
 }
 
 func TestConfigURL(t *testing.T) {
 	dsn := "http://username:password@localhost:8123/test?timeout=1s&idle_timeout=2s&read_timeout=3s" +
-		"&write_timeout=4s&location=Local&max_execution_time=10"
+		"&write_timeout=4s&location=Local&max_execution_time=10&priority=10"
 	cfg, err := ParseDSN(dsn)
 	if assert.NoError(t, err) {
 		u1 := cfg.url(nil, true).String()
-		assert.Equal(t, "http://username:password@localhost:8123/test?max_execution_time=10", u1)
+		assert.Contains(t, u1, "http://username:password@localhost:8123/test?")
+		assert.Contains(t, u1, "max_execution_time=10")
+		assert.Contains(t, u1, "priority=10")
 		u2 := cfg.url(map[string]string{"default_format": "Native"}, false).String()
 		assert.Contains(t, u2, "http://username:password@localhost:8123/?")
 		assert.Contains(t, u2, "default_format=Native")
 		assert.Contains(t, u2, "database=test")
+		assert.Contains(t, u2, "priority=10")
 	}
 }
 


### PR DESCRIPTION
Clickhouse can put priorities to queues (https://github.com/yandex/ClickHouse/blob/master/dbms/src/Interpreters/QueryPriorities.h). This PR adds priority support to dsn
