### PR TITLE
LowCardinality type dataparser support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ http://user:password@host:8123/clicks?read_timeout=10&write_timeout=20
 * Date
 * DateTime
 * Enum
+* LowCardinality(T)
 * [Array(T) (one-dimensional)](https://clickhouse.yandex/reference_en.html#Array(T))
 * [Nested(Name1 Type1, Name2 Type2, ...)](https://clickhouse.yandex/docs/en/data_types/nested_data_structures/nested/)
 

--- a/dataparser_test.go
+++ b/dataparser_test.go
@@ -253,6 +253,30 @@ func TestParseData(t *testing.T) {
 			inputdata:     "(1,2",
 			failParseData: true,
 		},
+		{
+			name:      "low cardinality string",
+			inputtype: "LowCardinality(String)",
+			inputdata: "hello",
+			output:    "hello",
+		},
+		{
+			name:      "low cardinality string with escaping",
+			inputtype: "LowCardinality(String)",
+			inputdata: `hello \'world`,
+			output:    "hello 'world",
+		},
+		{
+			name:          "low cardinality string with incorrect escaping",
+			inputtype:     "LowCardinality(String)",
+			inputdata:     `hello world\`,
+			failParseData: true,
+		},
+		{
+			name:      "low cardinality UInt64",
+			inputtype: "LowCardinality(UInt64)",
+			inputdata: "123",
+			output:    uint64(123),
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
When I select rows with LowCardinality field type without CAST I have an error: 
`type LowCardinality is not supported`
This is a fix.