### PR TITLE
Return original error when connection to ClickHouse failed

### DIFF
--- a/conn_go18.go
+++ b/conn_go18.go
@@ -14,9 +14,9 @@ import (
 // Ping implements the driver.Pinger
 func (c *conn) Ping(ctx context.Context) error {
 	if c.transport == nil {
-		return driver.ErrBadConn
+		return ErrTransportNil
 	}
-	// make request with empty body, response should be "Ok"
+	// make request with empty body, response must be "Ok"
 	u := &url.URL{Scheme: c.url.Scheme, User: c.url.User, Host: c.url.Host, Path: "/"}
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
@@ -27,11 +27,14 @@ func (c *conn) Ping(ctx context.Context) error {
 		c.cancel = nil
 	}()
 	if err != nil {
-		return driver.ErrBadConn
+		return err
 	}
 	resp, err := ioutil.ReadAll(respBody)
-	if err != nil || len(resp) != 4 || !strings.HasPrefix(string(resp), "Ok.") {
-		return driver.ErrBadConn
+	if err != nil {
+		return err
+	}
+	if len(resp) != 4 || !strings.HasPrefix(string(resp), "Ok.") {
+		return ErrIncorrectResponse
 	}
 	return nil
 }

--- a/errors.go
+++ b/errors.go
@@ -9,11 +9,13 @@ import (
 
 // Various errors the driver might return. Can change between driver versions.
 var (
-	ErrPlaceholderCount = errors.New("clickhouse: wrong placeholder count")
-	ErrNameParams       = errors.New("clickhouse: driver does not support the use of Named Parameters")
-	ErrMalformed        = errors.New("clickhouse: response is malformed")
-	ErrNoLastInsertID   = errors.New("no LastInsertId available")
-	ErrNoRowsAffected   = errors.New("no RowsAffected available")
+	ErrPlaceholderCount  = errors.New("clickhouse: wrong placeholder count")
+	ErrNameParams        = errors.New("clickhouse: driver does not support the use of Named Parameters")
+	ErrMalformed         = errors.New("clickhouse: response is malformed")
+	ErrTransportNil      = errors.New("clickhouse: transport must be set")
+	ErrIncorrectResponse = errors.New("clickhouse: response must contain 'Ok.'")
+	ErrNoLastInsertID    = errors.New("no LastInsertId available")
+	ErrNoRowsAffected    = errors.New("no RowsAffected available")
 )
 
 var errorRe = regexp.MustCompile(`(?s)Code: (\d+),.+DB::Exception: (.+),.*`)


### PR DESCRIPTION
When driver fails to connect to ClickHouse, the developers must
know the reason why it happened, this will dramatically help them
to solve the problem.

This commit reworks returned error for Ping method. Instead of
"bad connection", it will return the original error, when it occuirs.
Moreover, when the answer is not as expected (does not contain "Ok.")
the driver will explicitly return the message with the problem.
And for case when the transport is absent, developer will get explicit
message about it. There is no need to dive into the driver to catch
the responses to get to the bottom of the problem.