### PR TITLE
Array(Nullable(TypeName)) Parse() support

### DIFF
--- a/dataparser.go
+++ b/dataparser.go
@@ -99,8 +99,29 @@ func (p *nullableParser) Parse(s io.RuneScanner) (driver.Value, error) {
 
 		dB = bytes.NewBufferString(runes)
 	case reflectTypeTime:
-		d := readRaw(s)
-		dB = d
+		runes := ""
+
+		iter := 0
+		//not sure about safety ^^
+		for {
+			r, _, err := s.ReadRune()
+			if err != nil {
+				return nil, nil
+			}
+
+			runes += string(r)
+
+			if r == '\'' && iter != 0 {
+				break
+			}
+			iter++
+		}
+
+		if runes == "0000-00-00" || runes == "0000-00-00 00:00:00" {
+			return time.Time{}, nil
+		}
+
+		dB = bytes.NewBufferString(runes)
 	case reflectTypeEmptyStruct:
 		d := readRaw(s)
 		dB = d


### PR DESCRIPTION
I've noticed some time ago that array(nullable(TypeName)) arguments can not be read from ClickHouse database properly.
So there's a solution for some data types.
P.S. + some tests of course

dataparser.go: Array(Nullable(TypeName)) Parse() support where TypeName:
- UInt8-64
- Int8-64
- Float32-64
- String (also with escape seqs)
- Date (also with timezone)
- DateTime (also with timezone)
