### PR TITLE
Support Array(Nullable(TypeName)) Parse() 

### DIFF
--- a/dataparser.go
+++ b/dataparser.go
@@ -112,7 +112,6 @@ func (p *nullableParser) Parse(s io.RuneScanner) (driver.Value, error) {
 		runes := ""
 
 		iter := 0
-		//not sure about safety ^^
 		for {
 			r, _, err := s.ReadRune()
 			if err != nil {

--- a/dataparser.go
+++ b/dataparser.go
@@ -67,13 +67,21 @@ func (p *nullableParser) Parse(s io.RuneScanner) (driver.Value, error) {
 		dB = bytes.NewBufferString(d)
 	case reflectTypeString:
 		runes := ""
-
 		iter := 0
 		//not sure about safety ^^
+		isNotString := false
 		for {
 			r, _, err := s.ReadRune()
 			if err != nil {
 				return nil, nil
+			}
+
+			if r != '\'' && iter == 0 {
+				s.UnreadRune()
+				d := readRaw(s)
+				dB = d
+				isNotString = true
+				break
 			}
 
 			isEscaped := false
@@ -97,7 +105,9 @@ func (p *nullableParser) Parse(s io.RuneScanner) (driver.Value, error) {
 			iter++
 		}
 
-		dB = bytes.NewBufferString(runes)
+		if !isNotString {
+			dB = bytes.NewBufferString(runes)
+		}
 	case reflectTypeTime:
 		runes := ""
 

--- a/dataparser.go
+++ b/dataparser.go
@@ -99,8 +99,29 @@ func (p *nullableParser) Parse(s io.RuneScanner) (driver.Value, error) {
 
 		dB = bytes.NewBufferString(runes)
 	case reflectTypeTime:
-		d := readRaw(s)
-		dB = d
+		runes := ""
+
+		iter := 0
+		//not sure about safety ^^
+		for {
+			r, _, err := s.ReadRune()
+			if err != nil {
+				return nil, nil
+			}
+
+			runes += string(r)
+
+			if r == '\'' && iter != 0 {
+				break
+			}
+			iter++
+		}
+
+		if runes == "0000-00-00" || runes == "0000-00-00 00:00:00" {
+			return time.Time{}, nil
+		}
+
+		dB = bytes.NewBufferString(runes)
 	case reflectTypeEmptyStruct:
 		d := readRaw(s)
 		dB = d

--- a/dataparser_test.go
+++ b/dataparser_test.go
@@ -395,6 +395,48 @@ func TestParseDataNewNullableArray(t *testing.T) {
 
 	testCases := []*testCase{
 		{
+			name:      "nullable null string",
+			inputtype: "Nullable(String)",
+			inputdata: `\N`,
+			output:    nil,
+		},
+		{
+			name:      "nullable null UInt64",
+			inputtype: "Nullable(UInt64)",
+			inputdata: `\N`,
+			output:    nil,
+		},
+		{
+			name:      "nullable null decimal",
+			inputtype: "Nullable(Decimal)",
+			inputdata: `\N`,
+			output:    nil,
+		},
+		{
+			name:      "nullable null datetime",
+			inputtype: "Nullable(DateTime)",
+			inputdata: `\N`,
+			output:    nil,
+		},
+		{
+			name:      "nullable null enum",
+			inputtype: "Nullable(Enum8('hello' = 1, 'world' = 2))",
+			inputdata: `\N`,
+			output:    nil,
+		},
+		{
+			name:      "nullable null uuid",
+			inputtype: "Nullable(UUID)",
+			inputdata: `\N`,
+			output:    nil,
+		},
+		{
+			name:      "nullable null Date",
+			inputtype: "Nullable(Date)",
+			inputdata: `\N`,
+			output:    nil,
+		},
+		{
 			name:      "nullable(decimal)",
 			inputtype: "Nullable(Decimal(9,4))",
 			inputdata: "123",
@@ -574,7 +616,7 @@ func TestParseDataNewNullableArray(t *testing.T) {
 			name:          "malformed array(nullable(date))",
 			inputtype:     "Array(Nullable(Date))",
 			inputdata:     "['a000-00-00 00:00:00']",
-			output:        []time.Time{{},},
+			output:        []time.Time{{}},
 			failParseData: true,
 		},
 		{

--- a/dataparser_test.go
+++ b/dataparser_test.go
@@ -395,6 +395,31 @@ func TestParseDataNewNullableArray(t *testing.T) {
 
 	testCases := []*testCase{
 		{
+			name:      "nullable(decimal)",
+			inputtype: "Nullable(Decimal(9,4))",
+			inputdata: "123",
+			output:    "123",
+		},
+		{
+			name:      "nullable(enum)",
+			inputtype: "Nullable(Enum8('hello' = 1, 'world' = 2))",
+			inputdata: "hello",
+			output:    "hello",
+		},
+		{
+			name:      "nullable(uuid)",
+			inputtype: "Nullable(UUID)",
+			inputdata: "c79a9747-7cef-4b11-8177-380f7ed462a4",
+			output:    "c79a9747-7cef-4b11-8177-380f7ed462a4",
+		},
+		{
+			name:      "nullable low cardinality string",
+			inputtype: "Nullable(LowCardinality(String))",
+			inputdata: "hello",
+			output:    "hello",
+		},
+		//////////////////////////////////////////////////////
+		{
 			name:      "array(nullable(datetime)), without options and argument",
 			inputtype: "Array(Nullable(DateTime))",
 			inputdata: "['2018-01-02 12:34:56','0000-00-00 00:00:00']",

--- a/dataparser_test.go
+++ b/dataparser_test.go
@@ -395,6 +395,52 @@ func TestParseDataNewNullableArray(t *testing.T) {
 
 	testCases := []*testCase{
 		{
+			name:      "array of nullable null String",
+			inputtype: "Array(Nullable(String))",
+			inputdata: `['ss','\N','dd','ff']`,
+			output:    []string{"ss", "dd", "ff"},
+		},
+		{
+			name:      "array(nullable(uuid))",
+			inputtype: "Array(Nullable(UUID))",
+			inputdata: `['c79a9747-7cef-4b11-8177-380f7ed462a4','\N','00000000-0000-0000-0000-000000000000']`,
+			output:    []string{"c79a9747-7cef-4b11-8177-380f7ed462a4", "00000000-0000-0000-0000-000000000000"},
+		},
+		{
+			name:      "array of nullable null UInt64",
+			inputtype: "Array(Nullable(UInt64))",
+			inputdata: `[1,\N,5,9]`,
+			output:    []uint64{1, 5, 9},
+		},
+		{
+			name:      "array of nullable null UInt16",
+			inputtype: "Array(Nullable(UInt16))",
+			inputdata: `[1,2,\N]`,
+			output:    []uint16{1, 2},
+		},
+		{
+			name:          "malformed array(nullable(date))",
+			inputtype:     "Array(Nullable(Date))",
+			inputdata:     `['a000-00-00 00:00:00', '\N']`,
+			output:        []time.Time{{}},
+			failParseData: true,
+		},
+		{
+			name:      "array of nullable null Float64",
+			inputtype: "Array(Nullable(Float64))",
+			inputdata: `[1.9,\N,5.3,9.9]`,
+			output:    []float64{1.9, 5.3, 9.9},
+		},
+		{
+			name:      "array(nullable(datetime)), without options and argument",
+			inputtype: "Array(Nullable(DateTime))",
+			inputdata: `['2018-01-02 12:34:56','\N','0000-00-00 00:00:00']`,
+			output: []time.Time{
+				time.Date(2018, 1, 2, 12, 34, 56, 0, time.UTC),
+				{},
+			},
+		},
+		{
 			name:      "nullable null string",
 			inputtype: "Nullable(String)",
 			inputdata: `\N`,

--- a/dataparser_test.go
+++ b/dataparser_test.go
@@ -401,10 +401,22 @@ func TestParseDataNewNullableArray(t *testing.T) {
 			output:    "123",
 		},
 		{
+			name:      "array(nullable(decimal))",
+			inputtype: "Array(Nullable(Decimal(9,4)))",
+			inputdata: "['123','555.6']",
+			output:    []string{"123", "555.6"},
+		},
+		{
 			name:      "nullable(enum)",
 			inputtype: "Nullable(Enum8('hello' = 1, 'world' = 2))",
 			inputdata: "hello",
 			output:    "hello",
+		},
+		{
+			name:      "array(nullable(enum))",
+			inputtype: "Array(Nullable(Enum8('hello' = 1, 'world' = 2)))",
+			inputdata: "['hello','hi']",
+			output:    []string{"hello", "hi"},
 		},
 		{
 			name:      "nullable(uuid)",
@@ -413,10 +425,28 @@ func TestParseDataNewNullableArray(t *testing.T) {
 			output:    "c79a9747-7cef-4b11-8177-380f7ed462a4",
 		},
 		{
+			name:      "array(nullable(uuid))",
+			inputtype: "Array(Nullable(UUID))",
+			inputdata: "['c79a9747-7cef-4b11-8177-380f7ed462a4','00000000-0000-0000-0000-000000000000']",
+			output:    []string{"c79a9747-7cef-4b11-8177-380f7ed462a4", "00000000-0000-0000-0000-000000000000"},
+		},
+		{
 			name:      "nullable low cardinality string",
 			inputtype: "Nullable(LowCardinality(String))",
 			inputdata: "hello",
 			output:    "hello",
+		},
+		{
+			name:      "array of nullable low cardinality string",
+			inputtype: "Array(Nullable(LowCardinality(String)))",
+			inputdata: "['hello','hi']",
+			output:    []string{"hello", "hi"},
+		},
+		{
+			name:      "array of nullable low cardinality UInt64",
+			inputtype: "Array(Nullable(LowCardinality(UInt64)))",
+			inputdata: "[123,555]",
+			output:    []uint64{123, 555},
 		},
 		//////////////////////////////////////////////////////
 		{


### PR DESCRIPTION
I've noticed some time ago that Array(Nullable(TypeName)) elements can not be read from ClickHouse database properly.
So there's a solution for some data types.
P.S. + some tests of course
P.S.2. + fixed nil array element Parse() panic (dataparser.go:320)

dataparser.go: Array(Nullable(TypeName)) Parse() support where TypeName:
- UInt8-64
- Int8-64
- Float32-64
- String (also with escape seqs)
- Date (also with timezone)
- DateTime (also with timezone)
- Decimal
- Enum
- Uuid
- LowCardinality