### PR TITLE
Drain response body on exec call to enable keep-alive connection reuse

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -211,6 +212,8 @@ func (c *conn) killQuery(req *http.Request, args []driver.Value) error {
 		return err
 	}
 	if body != nil {
+		// Drain body to enable connection reuse
+		io.Copy(ioutil.Discard, body)
 		body.Close()
 	}
 	return nil
@@ -248,6 +251,8 @@ func (c *conn) exec(ctx context.Context, query string, args []driver.Value) (dri
 	}
 	body, err := c.doRequest(ctx, req)
 	if body != nil {
+		// Drain body to enable connection reuse
+		io.Copy(ioutil.Discard, body)
 		body.Close()
 	}
 	return emptyResult, err

--- a/conn_go18.go
+++ b/conn_go18.go
@@ -29,6 +29,8 @@ func (c *conn) Ping(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// Close response body to enable connection reuse
+	defer respBody.Close()
 	resp, err := ioutil.ReadAll(respBody)
 	if err != nil {
 		return err


### PR DESCRIPTION
Currently library generates big amount or errors on ClickHouse side:
<Error> ServerErrorHandler: Poco::Exception. Code: 1000, e.code() = 104, e.displayText() = Connection reset by peer
That's happens because of improper close of response body.
Documentation in net/http/response code states that to reuse keep-alive clients require to both read to competition and close body:
https://go.googlesource.com/go/+/go1.15.7/src/net/http/response.go#63
Unfortunately library only close response body without reading response body which leads to dropping keep-alive connections instead of reuse.
Also good discussion about this issue could be found here: https://github.com/google/go-github/pull/317
Tested on ClickHouse versions 19.16.12.49 and 20.8.12.2