### PR TITLE
using POST requests and changing the uuid library to google

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ http://user:password@host:8123/clicks?read_timeout=10&write_timeout=20
 * LowCardinality(T)
 * [Array(T) (one-dimensional)](https://clickhouse.yandex/reference_en.html#Array(T))
 * [Nested(Name1 Type1, Name2 Type2, ...)](https://clickhouse.yandex/docs/en/data_types/nested_data_structures/nested/)
+* IPv4, IPv6
 
 Notes:
-database/sql does not allow to use big uint64 values.
-It is recommended use type `UInt64` which is provided by driver for such kind of values.
-type `[]byte` are used as raw string (without quoting)
-for passing value of type `[]uint8` to driver as array - please use the wrapper `clickhouse.Array`
-for passing decimal value please use the wrappers `clickhouse.Decimal*`
-for passing IPv4/IPv6 types use `clickhouse.IP`
+* database/sql does not allow to use big uint64 values. It is recommended use type `UInt64` which is provided by driver for such kind of values.
+* type `[]byte` are used as raw string (without quoting)
+* for passing value of type `[]uint8` to driver as array - please use the wrapper `clickhouse.Array`
+* for passing decimal value please use the wrappers `clickhouse.Decimal*`
+* for passing IPv4/IPv6 types use `clickhouse.IP`
 
 ## Supported request params
 

--- a/conn_go18.go
+++ b/conn_go18.go
@@ -15,7 +15,7 @@ func (c *conn) Ping(ctx context.Context) error {
 		return ErrTransportNil
 	}
 
-	req, err := c.buildRequest(ctx, "select 1", nil, true)
+	req, err := c.buildRequest(ctx, "select 1", nil)
 	if err != nil {
 		return err
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -7,11 +7,11 @@ import (
 	"database/sql/driver"
 	"io/ioutil"
 	"net/http"
-	"net/url"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -180,10 +180,8 @@ func (s *connSuite) TestServerError() {
 
 func (s *connSuite) TestServerKillQuery() {
 	// kill query and check if it is cancelled
-	queryUUID, err := uuid.NewV4()
-	s.Require().NoError(err)
-	queryID := queryUUID.String()
-	_, err = s.connWithKillQuery.QueryContext(context.WithValue(context.Background(), QueryID, queryID), "SELECT sleep(3)")
+	queryID := uuid.New().String()
+	_, err := s.connWithKillQuery.QueryContext(context.WithValue(context.Background(), QueryID, queryID), "SELECT sleep(3)")
 	s.Error(err)
 	s.Contains(err.Error(), "net/http: timeout awaiting response headers")
 	rows := s.connWithKillQuery.QueryRow("SELECT count(query_id) FROM system.processes where query_id=? and is_cancelled=?", queryID, 1)
@@ -193,9 +191,7 @@ func (s *connSuite) TestServerKillQuery() {
 	s.Equal(1, amount)
 
 	// not kill query and check if it is not cancelled
-	queryUUID, err = uuid.NewV4()
-	s.Require().NoError(err)
-	queryID = queryUUID.String()
+	queryID = uuid.New().String()
 	_, err = s.connWithKillQuery.QueryContext(context.WithValue(context.Background(), QueryID, queryID), "SELECT sleep(0.5)")
 	s.NoError(err)
 	rows = s.connWithKillQuery.QueryRow("SELECT count(query_id) FROM system.processes where query_id=? and is_cancelled=?", queryID, 0)
@@ -212,21 +208,24 @@ func (s *connSuite) TestBuildRequestReadonlyWithAuth() {
 	cfg.User = "user"
 	cfg.Password = "password"
 	cn := newConn(cfg)
-	req, err := cn.buildRequest(context.Background(), "SELECT 1", nil, true)
+	req, err := cn.buildRequest(context.Background(), "SELECT 1", nil)
 	if s.NoError(err) {
 		user, password, ok := req.BasicAuth()
 		s.True(ok)
 		s.Equal("user", user)
 		s.Equal("password", password)
-		s.Equal(http.MethodGet, req.Method)
-		s.Equal(cn.url.String()+"&query="+url.QueryEscape("SELECT 1"), req.URL.String())
+		s.Equal(http.MethodPost, req.Method)
+		s.Equal(cn.url.String(), req.URL.String())
 		s.Nil(req.URL.User)
+		b, err := ioutil.ReadAll(req.Body)
+		s.Require().NoError(err)
+		s.Equal("SELECT 1", string(b))
 	}
 }
 
 func (s *connSuite) TestBuildRequestReadWriteWOAuth() {
 	cn := newConn(NewConfig())
-	req, err := cn.buildRequest(context.Background(), "INSERT 1 INTO num", nil, false)
+	req, err := cn.buildRequest(context.Background(), "INSERT 1 INTO num", nil)
 	if s.NoError(err) {
 		_, _, ok := req.BasicAuth()
 		s.False(ok)
@@ -271,7 +270,7 @@ func (s *connSuite) TestBuildRequestWithQueryId() {
 		},
 	}
 	for _, tc := range testCases {
-		req, err := cn.buildRequest(context.WithValue(context.Background(), QueryID, tc.queryID), "INSERT 1 INTO num", nil, false)
+		req, err := cn.buildRequest(context.WithValue(context.Background(), QueryID, tc.queryID), "INSERT 1 INTO num", nil)
 		if s.NoError(err) {
 			s.Equal(http.MethodPost, req.Method)
 			s.Equal(tc.expected, req.URL.String())
@@ -314,7 +313,7 @@ func (s *connSuite) TestBuildRequestWithQuotaKey() {
 		},
 	}
 	for _, tc := range testCases {
-		req, err := cn.buildRequest(context.WithValue(context.Background(), QuotaKey, tc.quotaKey), "SELECT 1", nil, false)
+		req, err := cn.buildRequest(context.WithValue(context.Background(), QuotaKey, tc.quotaKey), "SELECT 1", nil)
 		if s.NoError(err) {
 			s.Equal(http.MethodPost, req.Method)
 			s.Equal(tc.expected, req.URL.String())
@@ -363,7 +362,7 @@ func (s *connSuite) TestBuildRequestWithQueryIdAndQuotaKey() {
 		ctx := context.Background()
 		ctx = context.WithValue(ctx, QuotaKey, tc.quotaKey)
 		ctx = context.WithValue(ctx, QueryID, tc.queryID)
-		req, err := cn.buildRequest(ctx, "SELECT 1", nil, false)
+		req, err := cn.buildRequest(ctx, "SELECT 1", nil)
 		if s.NoError(err) {
 			s.Equal(http.MethodPost, req.Method)
 			s.Equal(tc.expected, req.URL.String())
@@ -373,7 +372,7 @@ func (s *connSuite) TestBuildRequestWithQueryIdAndQuotaKey() {
 func (s *connSuite) TestBuildRequestParamsInterpolation() {
 	query := `INSERT INTO test (str) VALUES ("Question?")`
 	cn := newConn(NewConfig())
-	req, err := cn.buildRequest(context.Background(), query, make([]driver.Value, 0), false)
+	req, err := cn.buildRequest(context.Background(), query, make([]driver.Value, 0))
 	if s.NoError(err) {
 		body, e := ioutil.ReadAll(req.Body)
 		if s.NoError(e) {
@@ -386,7 +385,7 @@ func (s *connSuite) TestRequestBodyGzipCompression() {
 	query := `INSERT INTO test (str) VALUES ("Question?")`
 	cn := newConn(NewConfig())
 	cn.useGzipCompression = true
-	req, err := cn.buildRequest(context.Background(), query, make([]driver.Value, 0), false)
+	req, err := cn.buildRequest(context.Background(), query, make([]driver.Value, 0))
 	if s.NoError(err) {
 		s.Contains(req.Header, "Content-Encoding")
 		gz, err := gzip.NewReader(req.Body)
@@ -396,6 +395,19 @@ func (s *connSuite) TestRequestBodyGzipCompression() {
 			if s.NoError(e) {
 				s.Equal(query, string(body))
 			}
+		}
+	}
+}
+
+func (s *connSuite) TestLongRequest() {
+	expected := strings.Repeat("x", 100000)
+	rows, err := s.conn.Query("SELECT ?", expected)
+	if s.NoError(err) {
+		rows.Next()
+		var actual string
+		err = rows.Scan(&actual)
+		if s.NoError(err) {
+			s.Equal(expected, actual)
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/mailru/go-clickhouse
 
 require (
-	github.com/gofrs/uuid v3.2.0+incompatible
+	github.com/google/uuid v1.2.0
 	github.com/stretchr/testify v1.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,9 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
-github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=


### PR DESCRIPTION
evolution of #115 
For using long SELECT's that are compatible to chproxy, we need to either put data in POST body or make a GET request with query parameter "query". 
As the request URL might be limited, we make all selects use POST requests.