### PR TITLE
Feature/golang ci lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,222 @@
+linters:
+  disable-all: true
+  fast: false
+  enable:
+    - govet
+    - errcheck
+    - staticcheck
+    - unused
+    - gosimple
+    - structcheck
+    - varcheck
+    - ineffassign
+    - deadcode
+    - typecheck
+    - bodyclose
+    - noctx
+#    - golint #deprecated
+    - rowserrcheck
+    - stylecheck
+    - gosec
+#    - interfacer #deprecated
+    - unconvert
+#    - dupl
+    - goconst
+#    - gocognit
+    - asciicheck
+    - gofmt
+#    - gofumpt
+#    - goimports
+#    - goheader
+    - gci
+#    - maligned
+    - depguard
+    - misspell
+#    - lll
+    - unparam
+    - dogsled
+    - nakedret
+#    - prealloc
+    - gocritic
+#    - gochecknoinits
+#    - gochecknoglobals
+#    - godox
+#    - funlen
+    - whitespace
+#    - wsl
+    - goprintffuncname
+#    - gomnd
+#    - goerr113
+#    - gomodguard
+#    - godot
+#    - testpackage
+#    - nestif
+    - exportloopref
+    - exhaustive
+    - sqlclosecheck
+    - forcetypeassert
+    - wastedassign
+    - gomoddirectives
+    - nilerr
+    - revive
+    - ifshort
+    - predeclared
+    - forbidigo
+    - makezero
+    - thelper
+#    - errorlint
+#    - wrapcheck
+    - tagliatelle
+#    - promlinter
+#    - paralleltest
+#    - tparallel
+#    - nlreturn
+    - nolintlint
+
+linters-settings:
+  gocritic:
+    settings:
+      captLocal: # must be valid enabled check name
+        # whether to restrict checker to params only (default true)
+        paramsOnly: true
+      elseif:
+        # whether to skip balanced if-else pairs (default true)
+        skipBalanced: true
+      hugeParam:
+        # size in bytes that makes the warning trigger (default 80)
+        sizeThreshold: 80
+      nestingReduce:
+        # min number of statements inside a branch to trigger a warning (default 5)
+        bodyWidth: 5
+      rangeExprCopy:
+        # size in bytes that makes the warning trigger (default 512)
+        sizeThreshold: 512
+        # whether to check test functions (default true)
+        skipTestFuncs: true
+      rangeValCopy:
+        # size in bytes that makes the warning trigger (default 128)
+        sizeThreshold: 32
+        # whether to check test functions (default true)
+        skipTestFuncs: true
+      ruleguard:
+        # path to a gorules file for the ruleguard checker
+        rules: ''
+      truncateCmp:
+        # whether to skip int/uint/uintptr types (default true)
+        skipArchDependent: true
+      underef:
+        # whether to skip (*x).method() calls where x is a pointer receiver (default true)
+        skipRecvDeref: true
+      unnamedResult:
+        # whether to check exported functions
+        checkExported: true
+  errcheck:
+    check-type-assertions: true
+    check-blank: false
+  govet:
+    check-shadowing: false
+  goconst:
+    min-len: 2
+    min-occurrences: 3
+  gofmt:
+    # simplify code: gofmt with `-s` option, true by default
+    simplify: false
+  revive:
+    # see https://github.com/mgechev/revive#available-rules for details.
+    ignore-generated-header: true
+    severity: warning
+    rules:
+      - name: indent-error-flow
+      - name: argument-limit
+        arguments: 4
+      - name: atomic
+#      - name: bare-return
+      - name: blank-imports
+      - name: confusing-results
+      - name: constant-logical-expr
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: deep-exit
+      - name: defer
+      - name: dot-imports
+      - name: early-return
+      - name: empty-block
+      - name: empty-lines
+      - name: error-return
+      - name: error-strings
+      - name: function-result-limit
+        arguments: 3
+      - name: if-return
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: import-shadowing
+      - name: modifies-parameter
+      - name: modifies-value-receiver
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: string-of-int
+      - name: struct-tag
+      - name: superfluous-else
+      - name: unexported-return
+      - name: unnecessary-stmt
+      - name: var-declaration
+      - name: time-naming
+  ifshort:
+    # Maximum length of variable declaration measured in number of lines, after which linter won't suggest using short syntax.
+    # Has higher priority than max-decl-chars.
+    max-decl-lines: 1
+    # Maximum length of variable declaration measured in number of characters, after which linter won't suggest using short syntax.
+    max-decl-chars: 30
+  predeclared:
+    # comma-separated list of predeclared identifiers to not report on
+    ignore: ""
+    # include method names and field names (i.e., qualified names) in checks
+    q: false
+  forbidigo:
+    # Forbid the following identifiers (identifiers are written using regexp):
+    forbid:
+      - ^print.*$
+      - 'fmt\.Print.*'
+    # Exclude godoc examples from forbidigo checks.  Default is true.
+    exclude_godoc_examples: false
+  makezero:
+    # Allow only slices initialized with a length of zero. Default is false.
+    always: false
+  errorlint:
+    # Check whether fmt.Errorf uses the %w verb for formatting errors. See the readme for caveats
+    errorf: true
+    # Check for plain type assertions and type switches
+    asserts: true
+    # Check for plain error comparisons
+    comparison: true
+  tagliatelle:
+    # check the struck tag name case
+    case:
+      # use the struct field name to check the name of the struct tag
+      use-field-name: true
+      rules:
+        # any struct tag type can be used.
+        # support string case: `camel`, `pascal`, `kebab`, `snake`, `goCamel`, `goPascal`, `goKebab`, `goSnake`, `upper`, `lower`
+        json: snake
+        yaml: snake
+  #        xml: camel
+  #        bson: camel
+  #        avro: snake
+  #        mapstructure: kebab
+  exhaustive:
+    # check switch statements in generated files also
+    check-generated: false
+    # indicates that switch statements are to be considered exhaustive if a
+    # 'default' case is present, even if all enum members aren't listed in the
+    # switch
+    default-signifies-exhaustive: true
+
+issues:
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    # Exclude some linters from running on tests files.
+    - path: _test\.go
+      linters:
+        - sqlclosecheck
+        - rowserrcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,10 +26,10 @@ linters:
     - asciicheck
     - gofmt
 #    - gofumpt
-#    - goimports
+    - goimports
 #    - goheader
     - gci
-#    - maligned
+#    - maligned #deprecated
     - depguard
     - misspell
 #    - lll
@@ -45,7 +45,7 @@ linters:
     - whitespace
 #    - wsl
     - goprintffuncname
-#    - gomnd
+    - gomnd
 #    - goerr113
 #    - gomodguard
 #    - godot
@@ -69,7 +69,7 @@ linters:
     - tagliatelle
 #    - promlinter
 #    - paralleltest
-#    - tparallel
+    - tparallel
 #    - nlreturn
     - nolintlint
 
@@ -211,6 +211,14 @@ linters-settings:
     # 'default' case is present, even if all enum members aren't listed in the
     # switch
     default-signifies-exhaustive: true
+  gomnd:
+    settings:
+      mnd:
+        # the list of enabled checks, see https://github.com/tommy-muehle/go-mnd/#checks for description.
+        checks: [argument,condition,operation,return,assign]
+        # ignored-numbers: 1000
+        # ignored-files: magic_.*.go
+        # ignored-functions: math.*
 
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 
 init:
 	GO111MODULE=on go mod vendor
-	GO111MODULE=on go get github.com/golangci/golangci-lint/...@v1.35.2
+	GO111MODULE=on go get github.com/golangci/golangci-lint/...@v1.40.1
 
 up_docker_server: stop_docker_server
 	docker run --rm=true -p 8123:8123 --name dbr-clickhouse-server -d yandex/clickhouse-server:latest;

--- a/config.go
+++ b/config.go
@@ -43,7 +43,7 @@ func NewConfig() *Config {
 // FormatDSN formats the given Config into a DSN string which can be passed to
 // the driver.
 func (cfg *Config) FormatDSN() string {
-	u := cfg.url(nil, true)
+	u := cfg.getURL(nil, true)
 	query := u.Query()
 	if cfg.Timeout != 0 {
 		query.Set("timeout", cfg.Timeout.String())
@@ -77,7 +77,7 @@ func (cfg *Config) FormatDSN() string {
 	return u.String()
 }
 
-func (cfg *Config) url(extra map[string]string, dsn bool) *url.URL {
+func (cfg *Config) getURL(extra map[string]string, dsn bool) *url.URL {
 	u := &url.URL{
 		Host:   ensureHavePort(cfg.Host),
 		Scheme: cfg.Scheme,
@@ -175,7 +175,7 @@ func parseDSNParams(cfg *Config, params map[string][]string) (err error) {
 		}
 	}
 
-	return
+	return nil
 }
 
 func ensureHavePort(addr string) string {

--- a/config_test.go
+++ b/config_test.go
@@ -87,9 +87,9 @@ func TestConfigURL(t *testing.T) {
 		"&write_timeout=4s&location=Local&max_execution_time=10"
 	cfg, err := ParseDSN(dsn)
 	if assert.NoError(t, err) {
-		u1 := cfg.url(nil, true).String()
+		u1 := cfg.getURL(nil, true).String()
 		assert.Equal(t, "http://username:password@localhost:8123/test?max_execution_time=10", u1)
-		u2 := cfg.url(map[string]string{"default_format": "Native"}, false).String()
+		u2 := cfg.getURL(map[string]string{"default_format": "Native"}, false).String()
 		assert.Contains(t, u2, "http://username:password@localhost:8123/?")
 		assert.Contains(t, u2, "default_format=Native")
 		assert.Contains(t, u2, "database=test")
@@ -111,7 +111,7 @@ func TestDefaultPort(t *testing.T) {
 	for _, tc := range testCases {
 		cfg, err = ParseDSN(tc.in)
 		if assert.NoError(t, err) {
-			assert.Equal(t, tc.out, cfg.url(nil, true).String())
+			assert.Equal(t, tc.out, cfg.getURL(nil, true).String())
 		}
 	}
 }

--- a/conn.go
+++ b/conn.go
@@ -275,7 +275,7 @@ func (c *conn) doRequest(ctx context.Context, req *http.Request) (io.ReadCloser,
 		c.cancel = nil
 		return nil, err
 	}
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		msg, err := readResponse(resp)
 		c.cancel = nil
 		if err == nil {

--- a/conn_test.go
+++ b/conn_test.go
@@ -184,9 +184,9 @@ func (s *connSuite) TestServerKillQuery() {
 	_, err := s.connWithKillQuery.QueryContext(context.WithValue(context.Background(), QueryID, queryID), "SELECT sleep(3)")
 	s.Error(err)
 	s.Contains(err.Error(), "net/http: timeout awaiting response headers")
-	rows := s.connWithKillQuery.QueryRow("SELECT count(query_id) FROM system.processes where query_id=? and is_cancelled=?", queryID, 1)
+	row := s.connWithKillQuery.QueryRow("SELECT count(query_id) FROM system.processes where query_id=? and is_cancelled=?", queryID, 1)
 	var amount int
-	err = rows.Scan(&amount)
+	err = row.Scan(&amount)
 	s.NoError(err)
 	s.Equal(1, amount)
 
@@ -194,8 +194,8 @@ func (s *connSuite) TestServerKillQuery() {
 	queryID = uuid.New().String()
 	_, err = s.connWithKillQuery.QueryContext(context.WithValue(context.Background(), QueryID, queryID), "SELECT sleep(0.1)")
 	s.NoError(err)
-	rows = s.connWithKillQuery.QueryRow("SELECT count(query_id) FROM system.processes where query_id=? and is_cancelled=?", queryID, 1)
-	err = rows.Scan(&amount)
+	row = s.connWithKillQuery.QueryRow("SELECT count(query_id) FROM system.processes where query_id=? and is_cancelled=?", queryID, 1)
+	err = row.Scan(&amount)
 	s.NoError(err)
 	s.Equal(0, amount)
 

--- a/dataparser_test.go
+++ b/dataparser_test.go
@@ -566,7 +566,7 @@ func TestParseDataNewNullableArray(t *testing.T) {
 			inputdata: "[123,555]",
 			output:    []uint64{123, 555},
 		},
-		//////////////////////////////////////////////////////
+		//-----------------------------------------------
 		{
 			name:      "array(nullable(datetime)), without options and argument",
 			inputtype: "Array(Nullable(DateTime))",
@@ -669,7 +669,7 @@ func TestParseDataNewNullableArray(t *testing.T) {
 			},
 			failParseData: true,
 		},
-		////////////////////////////////////////////////////
+		//-----------------------------------------------
 		{
 			name:      "array of dates",
 			inputtype: "Array(Date)",
@@ -707,7 +707,7 @@ func TestParseDataNewNullableArray(t *testing.T) {
 				{},
 			},
 		},
-		//////////////////////////////////////////////////
+		//-----------------------------------------------
 		{
 			name:      "array of ints",
 			inputtype: "Array(UInt64)",
@@ -733,7 +733,7 @@ func TestParseDataNewNullableArray(t *testing.T) {
 			output:        []uint64{},
 			failParseData: true,
 		},
-		//////////////////////////////////////////////////
+		//-----------------------------------------------
 		{
 			name:      "array of strings",
 			inputtype: "Array(String)",

--- a/encoder.go
+++ b/encoder.go
@@ -46,8 +46,9 @@ func (e *textEncoder) Encode(value driver.Value) ([]byte, error) {
 		return e.encodeArray(vv)
 	case reflect.Struct:
 		return e.encodeTuple(vv)
+	default:
+		return []byte(e.encode(value)), nil
 	}
-	return []byte(e.encode(value)), nil
 }
 
 func (e *textEncoder) encode(value driver.Value) string {

--- a/errors.go
+++ b/errors.go
@@ -33,7 +33,7 @@ func (e *Error) Error() string {
 
 func newError(resp string) error {
 	tokens := errorRe.FindStringSubmatch(resp)
-	if len(tokens) < 3 {
+	if len(tokens) < 3 { //nolint: gomnd
 		return fmt.Errorf("clickhouse: %s", resp)
 	}
 	code, _ := strconv.ParseInt(tokens[1], 10, 64)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/mailru/go-clickhouse
 
 require (
 	github.com/google/uuid v1.2.0
-	github.com/stretchr/testify v1.3.0
+	github.com/stretchr/testify v1.7.0
 )
 
-go 1.11
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -5,5 +5,9 @@ github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/stmt.go
+++ b/stmt.go
@@ -26,7 +26,7 @@ type stmt struct {
 func newStmt(query string) *stmt {
 	s := &stmt{pattern: query}
 	index := splitInsertRe.FindStringSubmatchIndex(strings.ToUpper(query))
-	if len(index) == 6 {
+	if len(index) == 6 { //nolint: gomnd
 		s.prefix = query[index[2]:index[3]]
 		s.pattern = query[index[4]:index[5]]
 		s.batchMode = true

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -109,7 +109,6 @@ func (s *stmtSuite) TestExec() {
 		_, err = st.Exec(tc.args[0]...)
 		s.EqualError(err, "sql: statement is closed")
 	}
-
 }
 
 func (s *stmtSuite) TestExecMulti() {

--- a/typeparser.go
+++ b/typeparser.go
@@ -12,12 +12,14 @@ type TypeDesc struct {
 
 func parseTypeDesc(tokens []*token) (*TypeDesc, []*token, error) {
 	var name string
-	if tokens[0].kind == 's' || tokens[0].kind == 'q' {
-		name = tokens[0].data
-		tokens = tokens[1:]
-	} else {
-		return nil, nil, fmt.Errorf("failed to parse type name: wrong token type '%c'", tokens[0].kind)
+
+	tokenKind := tokens[0].kind
+	if tokenKind != 's' && tokenKind != 'q' {
+		return nil, nil, fmt.Errorf("failed to parse type name: wrong token kind '%c'", tokenKind)
 	}
+
+	name = tokens[0].data
+	tokens = tokens[1:]
 
 	desc := TypeDesc{Name: name}
 	if tokens[0].kind != '(' {

--- a/value_converter.go
+++ b/value_converter.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 )
 
-func (stmt *stmt) ColumnConverter(idx int) driver.ValueConverter {
+func (s *stmt) ColumnConverter(idx int) driver.ValueConverter {
 	return converter{}
 }
 
@@ -40,7 +40,7 @@ func (c converter) ConvertValue(v interface{}) (driver.Value, error) {
 			return bytes, nil
 		}
 		return u64, nil
+	default:
+		return driver.DefaultParameterConverter.ConvertValue(v)
 	}
-
-	return driver.DefaultParameterConverter.ConvertValue(v)
 }


### PR DESCRIPTION
1. upgraded go version in `go.mod` (according to readme - Officially support last 3 golang releases) + upgraded testify library
2. not sure about [getURL](https://github.com/mailru/go-clickhouse/compare/master...finnan444:feature/golang-ci-lint-configuration?expand=1#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R80) a naming - the old one `url` shadows an import name. + added `nolint` to [log](https://github.com/mailru/go-clickhouse/compare/master...finnan444:feature/golang-ci-lint-configuration?expand=1#diff-4f427d2b022907c552328e63f137561f6de92396d7a6e8f6c2ea1bcf0db52654R91) function name - didnt come up with a good substitution.
3. [commented](https://github.com/mailru/go-clickhouse/compare/master...finnan444:feature/golang-ci-lint-configuration?expand=1#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9R133) rule `bare-return` of revive linter - discussble
4. Disabled 
- goerr113
- errorlint
- wrapcheck 

Can be enabled after discussion, as they will entail a rather cumbersome refactoring of errors in this project.