### PR TITLE
Add more information about what the occurred error means

### DIFF
--- a/conn_go18_test.go
+++ b/conn_go18_test.go
@@ -20,14 +20,14 @@ func (s *connSuite) TestQueryContext() {
 	ctx, cancel := context.WithCancel(context.Background())
 	time.AfterFunc(5*time.Millisecond, cancel)
 	_, err := s.conn.QueryContext(ctx, "SELECT sleep(3)")
-	s.EqualError(err, "context canceled")
+	s.EqualError(err, "doRequest: transport failed to send a request to ClickHouse: context canceled")
 }
 
 func (s *connSuite) TestExecContext() {
 	ctx, cancel := context.WithCancel(context.Background())
 	time.AfterFunc(5*time.Millisecond, cancel)
 	_, err := s.conn.ExecContext(ctx, "SELECT sleep(3)")
-	s.EqualError(err, "context canceled")
+	s.EqualError(err, "doRequest: transport failed to send a request to ClickHouse: context canceled")
 }
 
 func (s *connSuite) TestPing() {

--- a/rows.go
+++ b/rows.go
@@ -18,17 +18,17 @@ func newTextRows(c *conn, body io.ReadCloser, location *time.Location, useDBLoca
 
 	columns, err := tsvReader.Read()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("newTextRows: failed to parse the list of columns: %w", err)
 	}
 
 	types, err := tsvReader.Read()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("newTextRows: failed to parse the list of column types: %w", err)
 	}
 	for i := range types {
 		types[i], err = readUnquoted(strings.NewReader(types[i]), 0)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("newTextRows: failed to read the type '%s': %w", types[i], err)
 		}
 	}
 
@@ -36,7 +36,7 @@ func newTextRows(c *conn, body io.ReadCloser, location *time.Location, useDBLoca
 	for i, typ := range types {
 		desc, err := ParseTypeDesc(typ)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("newTextRows: failed to parse a description of the type '%s': %w", typ, err)
 		}
 
 		parsers[i], err = NewDataParser(desc, &DataParserOptions{
@@ -44,7 +44,7 @@ func newTextRows(c *conn, body io.ReadCloser, location *time.Location, useDBLoca
 			UseDBLocation: useDBLocation,
 		})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("newTextRows: failed to create a data parser for the type '%s': %w", typ, err)
 		}
 	}
 

--- a/stmt_go18_test.go
+++ b/stmt_go18_test.go
@@ -19,7 +19,7 @@ func (s *stmtSuite) TestQueryContext() {
 	s.Require().NoError(err)
 	time.AfterFunc(5*time.Millisecond, cancel)
 	_, err = st.QueryContext(ctx, 3)
-	s.EqualError(err, "context canceled")
+	s.EqualError(err, "doRequest: transport failed to send a request to ClickHouse: context canceled")
 	s.NoError(st.Close())
 }
 
@@ -29,7 +29,7 @@ func (s *stmtSuite) TestExecContext() {
 	s.Require().NoError(err)
 	time.AfterFunc(5*time.Millisecond, cancel)
 	_, err = st.ExecContext(ctx, 3)
-	s.EqualError(err, "context canceled")
+	s.EqualError(err, "doRequest: transport failed to send a request to ClickHouse: context canceled")
 	s.NoError(st.Close())
 }
 
@@ -41,6 +41,6 @@ func (s *stmtSuite) TestExecMultiContext() {
 	s.Require().NoError(err)
 	time.AfterFunc(10*time.Millisecond, cancel)
 	_, err = st.ExecContext(ctx, 3)
-	s.EqualError(err, "context canceled")
+	s.EqualError(err, "doRequest: transport failed to send a request to ClickHouse: context canceled")
 	s.NoError(st.Close())
 }


### PR DESCRIPTION
We have a few places where the library returns a raw error back to
the application. This is not a big problem if the error itself
provides enough information to identify the initial place/subsytem
where it occurred.

However, in this library some errors are confusing and it's unclear
where they happened and what actually they mean. As an example,
`driver: bad connection` or simply `EOF` were baffling me all the
time.

This commit makes errors more descriptive and keeps a possibility
to unwrap the initial error.