### PR TITLE
Fix parameters's example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ schema://user:password@host[:port]/database?param1=value1&...&paramN=valueN
 
 example:
 ```
-http://user:password@host:8123/clicks?read_timeout=10&write_timeout=20
+http://user:password@host:8123/clicks?read_timeout=10s&write_timeout=20s
 ```
 
 ## Supported data types


### PR DESCRIPTION
If the read_timeout and write_timeout in the example do not add a unit, the "time: missing unit in duration" exception will occur. It is recommended to add it to the README file.