### PR TITLE
add settings_params pass from context for request to ClickHouse

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -27,6 +27,9 @@ const (
 	QueryID key = iota
 	// QuotaKey uses for setting quota_key request param for request to Clickhouse
 	QuotaKey
+	// SettingsParams uses for custom setting request params for request to Clickhouse
+	// presented as map[string]string -> key1=value1&key2=value2... etc
+	SettingsParams
 
 	quotaKeyParamName = "quota_key"
 	queryIDParamName  = "query_id"
@@ -340,7 +343,18 @@ func (c *conn) buildRequest(ctx context.Context, query string, params []driver.V
 			reqQuery.Add(queryIDParamName, queryID)
 		}
 
+		settingsParams, settingsParamsOk := ctx.Value(SettingsParams).(map[string]string)
+		if settingsParamsOk && len(settingsParams) != 0 {
+			if reqQuery == nil {
+				reqQuery = req.URL.Query()
+			}
+
+			for name, value := range settingsParams {
+				reqQuery.Add(name, value)
+			}
+		}
 	}
+
 	if reqQuery != nil {
 		req.URL.RawQuery = reqQuery.Encode()
 	}

--- a/conn.go
+++ b/conn.go
@@ -27,9 +27,9 @@ const (
 	QueryID key = iota
 	// QuotaKey uses for setting quota_key request param for request to Clickhouse
 	QuotaKey
-	// SettingsParams uses for custom setting request params for request to Clickhouse
+	// RequestQueryParams uses for custom setting request params for request to Clickhouse
 	// presented as map[string]string -> key1=value1&key2=value2... etc
-	SettingsParams
+	RequestQueryParams
 
 	quotaKeyParamName = "quota_key"
 	queryIDParamName  = "query_id"
@@ -343,13 +343,13 @@ func (c *conn) buildRequest(ctx context.Context, query string, params []driver.V
 			reqQuery.Add(queryIDParamName, queryID)
 		}
 
-		settingsParams, settingsParamsOk := ctx.Value(SettingsParams).(map[string]string)
-		if settingsParamsOk && len(settingsParams) != 0 {
+		requestQueryParams, requestQueryParamsOk := ctx.Value(RequestQueryParams).(map[string]string)
+		if requestQueryParamsOk && len(requestQueryParams) != 0 {
 			if reqQuery == nil {
 				reqQuery = req.URL.Query()
 			}
 
-			for name, value := range settingsParams {
+			for name, value := range requestQueryParams {
 				reqQuery.Add(name, value)
 			}
 		}

--- a/conn_go18_test.go
+++ b/conn_go18_test.go
@@ -38,6 +38,18 @@ func (s *connSuite) TestPing() {
 	s.EqualError(s.conn.PingContext(ctx), "context canceled")
 }
 
+func (s *connSuite) TestPassSettingsParamsFromContext() {
+	ctx := context.WithValue(context.Background(), SettingsParams, map[string]string{
+		"max_read_buffer_size": "1",
+	})
+	s.NoError(s.conn.PingContext(ctx))
+
+	ctx = context.WithValue(context.Background(), SettingsParams, map[string]string{
+		"no_cache": "1",
+	})
+	s.EqualError(s.conn.PingContext(ctx), "Code: 115, Message: Unknown setting no_cache")
+}
+
 func (s *connSuite) TestColumnTypes() {
 	rows, err := s.conn.Query("SELECT * FROM data LIMIT 1")
 	s.Require().NoError(err)

--- a/conn_go18_test.go
+++ b/conn_go18_test.go
@@ -38,13 +38,13 @@ func (s *connSuite) TestPing() {
 	s.EqualError(s.conn.PingContext(ctx), "context canceled")
 }
 
-func (s *connSuite) TestPassSettingsParamsFromContext() {
-	ctx := context.WithValue(context.Background(), SettingsParams, map[string]string{
+func (s *connSuite) TestPassRequestQueryParamsFromContext() {
+	ctx := context.WithValue(context.Background(), RequestQueryParams, map[string]string{
 		"max_read_buffer_size": "1",
 	})
 	s.NoError(s.conn.PingContext(ctx))
 
-	ctx = context.WithValue(context.Background(), SettingsParams, map[string]string{
+	ctx = context.WithValue(context.Background(), RequestQueryParams, map[string]string{
 		"no_cache": "1",
 	})
 	s.EqualError(s.conn.PingContext(ctx), "Code: 115, Message: Unknown setting no_cache")


### PR DESCRIPTION
This feature will allow you to pass parameters to the service through the context. 
For example, it will be possible to control caching or labels in the request if you uses [chproxy](https://pkg.go.dev/github.com/richard403/chproxy#readme-caching)
