### PR TITLE
convert error header into request error

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -294,7 +294,7 @@ func (c *conn) doRequest(ctx context.Context, req *http.Request) (io.ReadCloser,
 		// response
 		return nil, newError(string(msg))
 	}
-	if errHeader, ok := resp.Header["X-ClickHouse-Exception-Code"]; ok {
+	if errHeader, ok := resp.Header[http.CanonicalHeaderKey("X-ClickHouse-Exception-Code")]; ok {
 		return nil, newError(strings.Join(errHeader, ", "))
 	}
 

--- a/conn.go
+++ b/conn.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -278,10 +279,10 @@ func (c *conn) doRequest(ctx context.Context, req *http.Request) (io.ReadCloser,
 		return nil, fmt.Errorf("doRequest: transport failed to send a request to ClickHouse: %w", err)
 	}
 
-        if err = callCtxTransportCallback(ctx, req, resp); err != nil {
-                c.cancel = nil
-                return nil, fmt.Errorf("doRequest: transport callback: %w", err)
-        }
+	if err = callCtxTransportCallback(ctx, req, resp); err != nil {
+		c.cancel = nil
+		return nil, fmt.Errorf("doRequest: transport callback: %w", err)
+	}
 
 	if resp.StatusCode != 200 {
 		msg, err := readResponse(resp)
@@ -292,6 +293,9 @@ func (c *conn) doRequest(ctx context.Context, req *http.Request) (io.ReadCloser,
 		// we got non-200 response, which means ClickHouse send an error in the
 		// response
 		return nil, newError(string(msg))
+	}
+	if errHeader, ok := resp.Header["X-ClickHouse-Exception-Code"]; ok {
+		return nil, newError(strings.Join(errHeader, ", "))
 	}
 
 	return resp.Body, nil


### PR DESCRIPTION
We recently noticed that the clickhouse http interface can return Status 200 ok for failing queries. In particular when clickhouse runs into a socket read timeout for inserts, it will return a 200 but not write any data. In these cases it injects an error header, which remains unevaluated in the libs current implementation. Also it's not possible to evaluate the response client-side because the response is discarded here: https://github.com/mailru/go-clickhouse/blob/master/stmt.go#L111
In order not to change the libs interface we suggest to raise an error, if the error header is present in the connection request code

The underlying issue is the same as for https://github.com/mailru/go-clickhouse/pull/107/files (which was closed). But the fix then (wait_query_end=1) won't help in our case, because the response body is not returned and doesn't contain an error. The error is only in the exception header